### PR TITLE
Added support for the send_at scheduling parameter.

### DIFF
--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -106,6 +106,15 @@ class SendgridBackend(BaseEmailBackend):
                 for k, v in msg.substitutions.items():
                     personalization.add_substitution(Substitution(k, v))
 
+        # write through the send_at attribute
+        if hasattr(msg, "send_at"):
+            if not isinstance(msg.send_at, int):
+                raise ValueError(
+                    "send_at must be an integer, got: {}; "
+                    "see https://sendgrid.com/docs/API_Reference/SMTP_API/scheduling_parameters.html#-Send-At".format(
+                        type(msg.send_at)))
+            personalization.send_at = msg.send_at
+
         mail.add_personalization(personalization)
 
         if hasattr(msg, "reply_to") and msg.reply_to:

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -79,6 +79,51 @@ class TestMailGeneration(SimpleTestCase):
 
         self.assertDictEqual(result, expected)
 
+    def test_EmailMessage_attributes(self):
+        """Test that send_at and categories attributes are correctly written through to output."""
+        msg = EmailMessage(
+            subject="Hello, World!",
+            body="Hello, World!",
+            from_email="Sam Smith <sam.smith@example.com>",
+            to=["John Doe <john.doe@example.com>", "jane.doe@example.com"],
+        )
+
+        # Set new attributes as message property
+        msg.send_at = 1518108670
+        msg.categories = ['mammal', 'dog']
+
+        result = self.backend._build_sg_mail(msg)
+        expected = {
+            "personalizations": [{
+                "to": [{
+                    "email": "john.doe@example.com",
+                    "name": "John Doe"
+                }, {
+                    "email": "jane.doe@example.com",
+                }],
+                "subject": "Hello, World!",
+                "send_at": 1518108670,
+            }],
+            "from": {
+                "email": "sam.smith@example.com",
+                "name": "Sam Smith"
+            },
+            "mail_settings": {
+                "sandbox_mode": {
+                    "enable": False
+                }
+            },
+            "subject": "Hello, World!",
+            "tracking_settings": {"open_tracking": {"enable": True}},
+            "content": [{
+                "type": "text/plain",
+                "value": "Hello, World!"
+            }],
+            "categories": ['mammal', 'dog'],
+        }
+
+        self.assertDictEqual(result, expected)
+
     def test_EmailMultiAlternatives(self):
         msg = EmailMultiAlternatives(
             subject="Hello, World!",


### PR DESCRIPTION
Scheduling parameter https://sendgrid.com/docs/API_Reference/SMTP_API/scheduling_parameters.html#-Send-At
is retrieved from the original message and written to the target. It is also checked for type as standard time.time() timestamp is float and is refused by SendGrid.