### PR TITLE
Add message_id and status code from sendgrid

### DIFF
--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -63,7 +63,9 @@ class SendgridBackend(BaseEmailBackend):
             data = self._build_sg_mail(msg)
 
             try:
-                self.sg.client.mail.send.post(request_body=data)
+                resp = self.sg.client.mail.send.post(request_body=data)
+                msg.extra_headers['status'] = resp.status_code
+                msg.extra_headers['message_id'] = resp.headers.getheader('x-message-id')
                 success += 1
             except HTTPError:
                 if not self.fail_silently:


### PR DESCRIPTION
Not sure how you want to handle this but this is how django_ses does it: https://github.com/django-ses/django-ses/blob/de427d11167a068bdc4835b383f6847018bd3504/django_ses/__init__.py#L202

Or is there another way to get the message_id back from sendgrid when sending a message?

I need this to match event webhooks.