### PR TITLE
Handle cases where Django 1.11 converts attachment content to unicode

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,5 @@
 venv
+.DS_Store
 *.sublime-*
 dist/
 build/

--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -177,9 +177,10 @@ class SendgridBackend(BaseEmailBackend):
                 filename, content, mimetype = attch
 
                 attachment.filename = filename
+                # Convert content from chars to bytes, in both Python 2 and 3.
                 # todo: Read content if stream?
                 if isinstance(content, str):
-                    content = content.encode()
+                    content = content.encode('utf-8')
                 attachment.content = base64.b64encode(content).decode()
                 attachment.type = mimetype
 

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -200,12 +200,12 @@ class TestMailGeneration(SimpleTestCase):
             bcc=["Sarah Smith <sarah.smith@example.com>"],
             reply_to=["Sam Smith <sam.smith@example.com>"],
         )
-
         msg.attach_alternative("<body<div>Hello World!</div></body>", "text/html")
 
         # Test CSV attachment
-        msg.attach("file.xls", b'\xd0', "application/vnd.ms-excel")
-        msg.attach("file.csv", "C\xc3\xb4te d\xe2\x80\x99Ivoire", "text/csv")
+        msg.attach("file.xls", b"\xd0", "application/vnd.ms-excel")
+        msg.attach("file.csv", b"C\xc3\xb4te d\xe2\x80\x99Ivoire", "text/csv")
+
         result = self.backend._build_sg_mail(msg)
         expected = {
             "personalizations": [{

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -205,6 +205,7 @@ class TestMailGeneration(SimpleTestCase):
 
         # Test CSV attachment
         msg.attach("file.xls", b'\xd0', "application/vnd.ms-excel")
+        msg.attach("file.csv", "C\xc3\xb4te d\xe2\x80\x99Ivoire", "text/csv")
         result = self.backend._build_sg_mail(msg)
         expected = {
             "personalizations": [{
@@ -239,11 +240,18 @@ class TestMailGeneration(SimpleTestCase):
             },
             "subject": "Hello, World!",
             "tracking_settings": {"open_tracking": {"enable": True}},
-            "attachments": [{
-                "content": "0A==",
-                "filename": "file.xls",
-                "type": "application/vnd.ms-excel"
-            }],
+            "attachments": [
+                {
+                    "content": "0A==",
+                    "filename": "file.xls",
+                    "type": "application/vnd.ms-excel"
+                },
+                {
+                    "content": "Q8O0dGUgZOKAmUl2b2lyZQ==",
+                    "filename": "file.csv",
+                    "type": "text/csv"
+                }
+            ],
             "content": [{
                 "type": "text/plain",
                 "value": " ",


### PR DESCRIPTION
Django 1.11+ converts the content of email attachments to unicode if the attachment content type is `text/*`. See https://github.com/django/django/blob/stable/1.11.x/django/core/mail/message.py#L379. For Python2 applications, this library was trying to re-encode the content as if it was ascii, which would error on unicode characters. 

Explicitly encode utf-8, rather than relying on the Python default encoding. Also add a test case.