### PR TITLE
Fixes tests

### DIFF
--- a/test/test_echo_to_stream.py
+++ b/test/test_echo_to_stream.py
@@ -4,10 +4,13 @@ if sys.version_info >= (3.0, 0.0):
     from unittest.mock import MagicMock
 else:
     from mock import MagicMock
+import warnings
 
 from django.core.mail import EmailMessage
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
+
+from python_http_client.exceptions import UnauthorizedError
 
 from sendgrid_backend.mail import SendgridBackend
 
@@ -19,7 +22,6 @@ class TestEchoToOutput(SimpleTestCase):
             "SENDGRID_API_KEY": "DOESNT_MATTER",
             "EMAIL_BACKEND": "sendgrid_backend.SendgridBackend",
             "SENDGRID_ECHO_TO_STDOUT": True,
-            "SENDGRID_SANDBOX_MODE_IN_DEBUG": True,
         }
         with override_settings(**settings):
             mocked_output_stream = MagicMock()
@@ -31,5 +33,12 @@ class TestEchoToOutput(SimpleTestCase):
                 to=["John Doe <john.doe@example.com>"],
                 connection=connection,
             )
-            msg.send()
+            try:
+                msg.send()
+            except UnauthorizedError:
+                # Since TravisCI doesn't allow environment variables to be injected on PRs (for security),
+                # we will get an unauthorized error when attempting to hit the sendgrid api endpoint, even in
+                # sandbox mode.
+                warnings.warn("Sendgrid requests using sandbox mode still need valid credentials for the " +
+                              "request to succeed.")
             self.assertTrue(mocked_output_stream.write.called)

--- a/test/test_echo_to_stream.py
+++ b/test/test_echo_to_stream.py
@@ -16,9 +16,10 @@ class TestEchoToOutput(SimpleTestCase):
     def test_echo(self):
         settings = {
             "DEBUG": True,
-            "SENDGRID_API_KEY": "DUMMY_KEY",
+            "SENDGRID_API_KEY": "DOESNT_MATTER",
             "EMAIL_BACKEND": "sendgrid_backend.SendgridBackend",
-            "SENDGRID_ECHO_TO_STDOUT": True
+            "SENDGRID_ECHO_TO_STDOUT": True,
+            "SENDGRID_SANDBOX_MODE_IN_DEBUG": True,
         }
         with override_settings(**settings):
             mocked_output_stream = MagicMock()

--- a/test/test_echo_to_stream.py
+++ b/test/test_echo_to_stream.py
@@ -16,7 +16,7 @@ class TestEchoToOutput(SimpleTestCase):
     def test_echo(self):
         settings = {
             "DEBUG": True,
-            "SENDGRID_API_KEY": os.environ["SENDGRID_API_KEY"],
+            "SENDGRID_API_KEY": "DUMMY_KEY",
             "EMAIL_BACKEND": "sendgrid_backend.SendgridBackend",
             "SENDGRID_ECHO_TO_STDOUT": True
         }


### PR DESCRIPTION
Sendgrid still requires authentication for requests in sandbox mode, but travis doesn't let us use environment variables for PRs for security reasons.  This fixes the failing test.