### PR TITLE
Fixes outlined in pull #93

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+.env
+.venv
+env
 venv
 .DS_Store
 *.sublime-*

--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -273,7 +273,7 @@ class SendgridBackend(BaseEmailBackend):
         if existing_personalizations is None:
             if not to:
                 raise ValueError(
-                    "Either msg.to or msg.personalizations (with to) is must be set"
+                    "Either msg.to or msg.personalizations (with recipients) must be set"
                 )
 
             personalization = Personalization()

--- a/sendgrid_backend/util.py
+++ b/sendgrid_backend/util.py
@@ -33,7 +33,7 @@ def dict_to_personalization(data: Dict[Any, Any]) -> Personalization:
     ]
     for attr in properties:
         if attr in ["tos", "ccs", "bccs"]:
-            key = attr[:-1]
+            key = attr[:-1]  # this searches the data for ["to", "cc", "bcc"]
         else:
             key = attr
 

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -623,13 +623,15 @@ class TestMailGeneration(SimpleTestCase):
         personalization.add_substitution(Substitution(test_key_str, test_val_str))
 
         msg.personalizations = [personalization]
-        with self.assertRaises(ValueError, self.backend._build_sg_mail, msg) as e:
-            self.assertEqual(str(e), "Each msg personalization must have recipients")
+        with self.assertRaises(ValueError) as e1:
+            res = self.backend._build_sg_mail(msg)
+        self.assertEqual(str(e1), "Each msg personalization must have recipients")
 
         delattr(msg, "personalizations")
         msg.dynamic_template_data = {"obi_wan": "hello there"}
-        with self.assertRaises(ValueError, self.backend._build_sg_mail, msg) as e:
-            self.assertEqual(
-                str(e),
-                "Either msg.to or msg.personalizations (with recipients) must be set",
-            )
+        with self.assertRaises(ValueError, self.backend._build_sg_mail, msg) as e2:
+            res = self.backend._build_sg_mail(msg)
+        self.assertEqual(
+            str(e2),
+            "Either msg.to or msg.personalizations (with recipients) must be set",
+        )

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -595,3 +595,41 @@ class TestMailGeneration(SimpleTestCase):
                 self.assertDictEqual(val, data[key])
             else:
                 self.assertEquals(val, data[key])
+
+    def test_build_personalization_errors(self):
+        msg = EmailMessage(
+            subject="Hello, World!",
+            body="Hello, World!",
+            from_email="Sam Smith <sam.smith@example.com>",
+            cc=["Stephanie Smith <stephanie.smith@example.com>"],
+            bcc=["Sarah Smith <sarah.smith@example.com>"],
+            reply_to=["Sam Smith <sam.smith@example.com>"],
+        )
+
+        test_str = "admin@my-test-domain.com"
+        test_key_str = "my key"
+        test_val_str = "my val"
+        personalization = Personalization()
+
+        if SENDGRID_5:
+            personalization.add_cc(Email(test_str))
+            personalization.add_bcc(Email(test_str))
+        else:
+            personalization.add_cc(Cc(test_str))
+            personalization.add_bcc(Bcc(test_str))
+
+        personalization.add_custom_arg(CustomArg(test_key_str, test_val_str))
+        personalization.add_header(Header(test_key_str, test_val_str))
+        personalization.add_substitution(Substitution(test_key_str, test_val_str))
+
+        msg.personalizations = [personalization]
+        with self.assertRaises(ValueError, self.backend._build_sg_mail, msg) as e:
+            self.assertEqual(str(e), "Each msg personalization must have recipients")
+
+        delattr(msg, "personalizations")
+        msg.dynamic_template_data = {"obi_wan": "hello there"}
+        with self.assertRaises(ValueError, self.backend._build_sg_mail, msg) as e:
+            self.assertEqual(
+                str(e),
+                "Either msg.to or msg.personalizations (with recipients) must be set",
+            )

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -634,7 +634,7 @@ class TestMailGeneration(SimpleTestCase):
         msg.dynamic_template_data = {"obi_wan": "hello there"}
         self.assertRaisesRegex(
             ValueError,
-            "Either msg.to or msg.personalizations (with recipients) must be set",
+            r"Either msg\.to or msg\.personalizations \(with recipients\) must be set",
             self.backend._build_sg_mail,
             msg,
         )

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -623,15 +623,18 @@ class TestMailGeneration(SimpleTestCase):
         personalization.add_substitution(Substitution(test_key_str, test_val_str))
 
         msg.personalizations = [personalization]
-        with self.assertRaises(ValueError) as e1:
-            res = self.backend._build_sg_mail(msg)
-        self.assertEqual(e1.message, "Each msg personalization must have recipients")
+        self.assertRaisesRegex(
+            ValueError,
+            "Each msg personalization must have recipients",
+            self.backend._build_sg_mail,
+            msg,
+        )
 
         delattr(msg, "personalizations")
         msg.dynamic_template_data = {"obi_wan": "hello there"}
-        with self.assertRaises(ValueError) as e2:
-            res = self.backend._build_sg_mail(msg)
-        self.assertEqual(
-            e2.message,
+        self.assertRaisesRegex(
+            ValueError,
             "Either msg.to or msg.personalizations (with recipients) must be set",
+            self.backend._build_sg_mail,
+            msg,
         )

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -625,13 +625,13 @@ class TestMailGeneration(SimpleTestCase):
         msg.personalizations = [personalization]
         with self.assertRaises(ValueError) as e1:
             res = self.backend._build_sg_mail(msg)
-        self.assertEqual(str(e1), "Each msg personalization must have recipients")
+        self.assertEqual(e1.message, "Each msg personalization must have recipients")
 
         delattr(msg, "personalizations")
         msg.dynamic_template_data = {"obi_wan": "hello there"}
         with self.assertRaises(ValueError) as e2:
             res = self.backend._build_sg_mail(msg)
         self.assertEqual(
-            str(e2),
+            e2.message,
             "Either msg.to or msg.personalizations (with recipients) must be set",
         )

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -629,7 +629,7 @@ class TestMailGeneration(SimpleTestCase):
 
         delattr(msg, "personalizations")
         msg.dynamic_template_data = {"obi_wan": "hello there"}
-        with self.assertRaises(ValueError, self.backend._build_sg_mail, msg) as e2:
+        with self.assertRaises(ValueError) as e2:
             res = self.backend._build_sg_mail(msg)
         self.assertEqual(
             str(e2),


### PR DESCRIPTION
- _build_sg_personalization "to" arg now changed to optional; either it or existing_personalizations must be set.
- Prevent using .personalizations without tos set.
- Prevent unnecessary resetting of tos when personalization is already constructed.

- No longer provide tos if not set for personalizations. This is to prevent every personalization from being sent to every recipient in msg.to

- Added/Changed some comments/docstrings to reduce ambiguity