### PR TITLE
Django 3.2 Support

### DIFF
--- a/sendgrid_backend/signals.py
+++ b/sendgrid_backend/signals.py
@@ -1,3 +1,3 @@
 import django.dispatch
 
-sendgrid_email_sent = django.dispatch.Signal(providing_args=["message", "fail_flag"])
+sendgrid_email_sent = django.dispatch.Signal()

--- a/tox.ini
+++ b/tox.ini
@@ -1,6 +1,6 @@
 [tox]
 envlist =
-    py{36,37,38,39}-django{18,110,111,21,22,3,31}-sendgrid{5,6}
+    py{36,37,38,39}-django{18,110,111,21,22,3,31,32}-sendgrid{5,6}
 
 [gh-actions]
 python =
@@ -18,6 +18,7 @@ deps =
     django22: Django>=2.2,<2.3
     django3: Django>=3.0,<3.1
     django31: Django>=3.1,<3.2
+    django32: Django>=3.2,<4
     sendgrid5: sendgrid>=5,<6
     sendgrid6: sendgrid>=6,<7
     -rdev-requirements.txt


### PR DESCRIPTION
- added Django 3.2 to tox
- Removed the purely documentational `providing_args` argument for Signal which was deprecated in 3.1 and will be removed in 4.0