### PR TITLE
Addresses issue #98, configurable tracking per-email

### DIFF
--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -479,11 +479,18 @@ class SendgridBackend(BaseEmailBackend):
         mail_settings.sandbox_mode = SandBoxMode(self.sandbox_mode)
         mail.mail_settings = mail_settings
 
-        tracking_settings = TrackingSettings()
-        tracking_settings.open_tracking = OpenTracking(self.track_email)
-        tracking_settings.click_tracking = ClickTracking(
-            self.track_clicks_html, self.track_clicks_plain
-        )
+        # Handle email tracking
+        tracking_settings = getattr(msg, 'tracking_settings', None)
+        if not isinstance(tracking_settings, TrackingSettings):
+            tracking_settings = TrackingSettings()
+
+        if tracking_settings.open_tracking is None:
+            tracking_settings.open_tracking = OpenTracking(self.track_email)
+
+        if tracking_settings.click_tracking is None:
+            tracking_settings.click_tracking = ClickTracking(
+                self.track_clicks_html, self.track_clicks_plain
+            )
 
         mail.tracking_settings = tracking_settings
 

--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -480,7 +480,7 @@ class SendgridBackend(BaseEmailBackend):
         mail.mail_settings = mail_settings
 
         # Handle email tracking
-        tracking_settings = getattr(msg, 'tracking_settings', None)
+        tracking_settings = getattr(msg, "tracking_settings", None)
         if not isinstance(tracking_settings, TrackingSettings):
             tracking_settings = TrackingSettings()
 

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -659,9 +659,16 @@ class TestMailGeneration(SimpleTestCase):
             utm_campaign="my-campaign",
             utm_medium="my-medium",
         )
-        msg.tracking_settings = TrackingSettings(
-            ganalytics=ganalytics, click_tracking=ClickTracking(enable=False)
-        )
+        if SENDGRID_5:
+            tracking_settings = TrackingSettings()
+            tracking_settings.ganalytics = ganalytics
+            tracking_settings.click_tracking = ClickTracking(enable=False)
+            msg.tracking_settings = tracking_settings
+        else:
+            msg.tracking_settings = TrackingSettings(
+                ganalytics=ganalytics, click_tracking=ClickTracking(enable=False)
+            )
+
         mail = self.backend._build_sg_mail(msg)
 
         tracking_settings = mail.get("tracking_settings")

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -1,9 +1,11 @@
 import base64
 from email.mime.image import MIMEImage
+from unittest.case import SkipTest
 
 from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
+from nose.plugins import skip
 from sendgrid.helpers.mail import (
     ClickTracking,
     CustomArg,
@@ -14,6 +16,7 @@ from sendgrid.helpers.mail import (
     Substitution,
     TrackingSettings,
 )
+from sendgrid.helpers.mail.open_tracking import OpenTracking
 
 from sendgrid_backend.mail import SendgridBackend
 from sendgrid_backend.util import SENDGRID_5, SENDGRID_6, dict_to_personalization
@@ -653,19 +656,41 @@ class TestMailGeneration(SimpleTestCase):
             reply_to=["Sam Smith <sam.smith@example.com>"],
         )
 
-        ganalytics = Ganalytics(
-            enable=True,
-            utm_source="my-source",
-            utm_campaign="my-campaign",
-            utm_medium="my-medium",
-        )
         msg.tracking_settings = TrackingSettings(
-            ganalytics=ganalytics, click_tracking=ClickTracking(enable=False)
+            click_tracking=ClickTracking(enable=False),
+            open_tracking=OpenTracking(enable=False),
         )
         mail = self.backend._build_sg_mail(msg)
 
         tracking_settings = mail.get("tracking_settings")
         assert tracking_settings
         assert not tracking_settings["click_tracking"]["enable"]
+        assert not tracking_settings["open_tracking"]["enable"]
+
+    def test_ganalytics_tracking(self):
+        if SENDGRID_5:
+            raise SkipTest()
+
+        msg = EmailMessage(
+            subject="Hello, World!",
+            body="Hello, World!",
+            from_email="Sam Smith <sam.smith@example.com>",
+            to=["John Doe <john.doe@example.com>", "jane.doe@example.com"],
+            cc=["Stephanie Smith <stephanie.smith@example.com>"],
+            bcc=["Sarah Smith <sarah.smith@example.com>"],
+            reply_to=["Sam Smith <sam.smith@example.com>"],
+        )
+
+        ganalytics = Ganalytics(
+            enable=True,
+            utm_source="my-source",
+            utm_campaign="my-campaign",
+            utm_medium="my-medium",
+        )
+        msg.tracking_settings = TrackingSettings(ganalytics=ganalytics)
+        mail = self.backend._build_sg_mail(msg)
+
+        tracking_settings = mail.get("tracking_settings")
+        assert tracking_settings
         assert "ganalytics" in tracking_settings
         assert tracking_settings["ganalytics"]["utm_source"] == "my-source"

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -5,11 +5,14 @@ from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
 from sendgrid.helpers.mail import (
+    ClickTracking,
     CustomArg,
     Email,
+    Ganalytics,
     Header,
     Personalization,
     Substitution,
+    TrackingSettings,
 )
 
 from sendgrid_backend.mail import SendgridBackend
@@ -638,3 +641,29 @@ class TestMailGeneration(SimpleTestCase):
             self.backend._build_sg_mail,
             msg,
         )
+
+    def test_tracking_config(self):
+        msg = EmailMessage(
+            subject="Hello, World!",
+            body="Hello, World!",
+            from_email="Sam Smith <sam.smith@example.com>",
+            to=["John Doe <john.doe@example.com>", "jane.doe@example.com"],
+            cc=["Stephanie Smith <stephanie.smith@example.com>"],
+            bcc=["Sarah Smith <sarah.smith@example.com>"],
+            reply_to=["Sam Smith <sam.smith@example.com>"],
+        )
+
+        ganalytics = Ganalytics(
+            enable=True,
+            utm_source='my-source',
+            utm_campaign='my-campaign',
+            utm_medium='my-medium',
+        )
+        msg.tracking_settings = TrackingSettings(ganalytics=ganalytics, click_tracking=ClickTracking(enable=False))
+        mail = self.backend._build_sg_mail(msg)
+
+        tracking_settings = mail.get('tracking_settings')
+        assert tracking_settings
+        assert not tracking_settings['click_tracking']['enable']
+        assert 'ganalytics' in tracking_settings
+        assert tracking_settings['ganalytics']['utm_source'] == 'my-source'

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -655,15 +655,17 @@ class TestMailGeneration(SimpleTestCase):
 
         ganalytics = Ganalytics(
             enable=True,
-            utm_source='my-source',
-            utm_campaign='my-campaign',
-            utm_medium='my-medium',
+            utm_source="my-source",
+            utm_campaign="my-campaign",
+            utm_medium="my-medium",
         )
-        msg.tracking_settings = TrackingSettings(ganalytics=ganalytics, click_tracking=ClickTracking(enable=False))
+        msg.tracking_settings = TrackingSettings(
+            ganalytics=ganalytics, click_tracking=ClickTracking(enable=False)
+        )
         mail = self.backend._build_sg_mail(msg)
 
-        tracking_settings = mail.get('tracking_settings')
+        tracking_settings = mail.get("tracking_settings")
         assert tracking_settings
-        assert not tracking_settings['click_tracking']['enable']
-        assert 'ganalytics' in tracking_settings
-        assert tracking_settings['ganalytics']['utm_source'] == 'my-source'
+        assert not tracking_settings["click_tracking"]["enable"]
+        assert "ganalytics" in tracking_settings
+        assert tracking_settings["ganalytics"]["utm_source"] == "my-source"


### PR DESCRIPTION
Closes https://github.com/sklarsa/django-sendgrid-v5/issues/98 by adding more granular email tracking capabilities