### PR TITLE
Allow custom MailSettings to be applied

### DIFF
--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -484,8 +484,13 @@ class SendgridBackend(BaseEmailBackend):
             else:
                 mail.asm = ASM(msg.asm["group_id"])
 
-        mail_settings = MailSettings()
+        # Add sandbox mode to mail settings
+        mail_settings = getattr(msg, "mail_settings", None)
+        if not isinstance(mail_settings, MailSettings):
+            mail_settings = MailSettings()
+
         mail_settings.sandbox_mode = SandBoxMode(self.sandbox_mode)
+
         mail.mail_settings = mail_settings
 
         # Handle email tracking

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -5,8 +5,7 @@ from django.core.mail import EmailMessage, EmailMultiAlternatives
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
 from sendgrid.helpers.mail import (
-    BypassBounceManagement,
-    BypassSpamManagement,
+    BypassListManagement,
     ClickTracking,
     CustomArg,
     Email,
@@ -14,6 +13,7 @@ from sendgrid.helpers.mail import (
     Header,
     MailSettings,
     Personalization,
+    SpamCheck,
     Substitution,
     TrackingSettings,
 )
@@ -680,18 +680,18 @@ class TestMailGeneration(SimpleTestCase):
             reply_to=["Sam Smith <sam.smith@example.com>"],
         )
 
-        msg.mail_settings = MailSettings(
-            bypass_bounce_management=BypassBounceManagement(enable=True),
-            bypass_spam_management=BypassBounceManagement(enable=False),
-        )
+        mail_settings = MailSettings()
+        mail_settings.bypass_list_management = BypassListManagement(enable=True)
+        mail_settings.spam_check = BypassListManagement(enable=False)
+        msg.mail_settings = mail_settings
 
         mail = self.backend._build_sg_mail(msg)
 
         mail_settings = mail.get("mail_settings")
         assert mail_settings
-        assert mail_settings["bypass_bounce_management"]["enable"]
-        assert not mail_settings["bypass_spam_management"]["enable"]
-        assert not "bypass_list_management" in mail_settings
+        assert mail_settings["bypass_list_management"]["enable"]
+        assert not mail_settings["spam_check"]["enable"]
+        assert not "bcc_settings" in mail_settings
 
     def test_tracking_config(self):
         msg = EmailMessage(

--- a/test/test_sandbox_mode.py
+++ b/test/test_sandbox_mode.py
@@ -25,9 +25,9 @@ class TestSandboxMode(SimpleTestCase):
             to=["John Doe <john.doe@example.com>"],
         )
         # additional setting to test existing settings preserved then sandbox_mode populated
-        msg_with_settings.mail_settings = MailSettings(
-            bypass_list_management=BypassListManagement(enable=True)
-        )
+        mail_settings = MailSettings()
+        mail_settings.bypass_list_management = BypassListManagement(enable=True)
+        msg_with_settings.mail_settings = mail_settings
 
         # Sandbox mode should be False
         with override_settings(DEBUG=False, SENDGRID_SANDBOX_MODE_IN_DEBUG=True):

--- a/test/test_sandbox_mode.py
+++ b/test/test_sandbox_mode.py
@@ -1,6 +1,7 @@
 from django.core.mail import EmailMessage
 from django.test import override_settings
 from django.test.testcases import SimpleTestCase
+from sendgrid.helpers.mail import BypassListManagement, MailSettings
 
 from sendgrid_backend.mail import SendgridBackend
 
@@ -8,14 +9,24 @@ from sendgrid_backend.mail import SendgridBackend
 class TestSandboxMode(SimpleTestCase):
     def test_sandbox_mode(self):
         """
-        Tests combinations of DEBUG and SENDGRID_SANDBOX_MODE_IN_DEBUG to ensure that
-        the behavior is as expected.
+        Tests combinations of DEBUG, SENDGRID_SANDBOX_MODE_IN_DEBUG, and mail_settings to ensure
+        that the behavior is as expected.
         """
         msg = EmailMessage(
             subject="Hello, World!",
             body="Hello, World!",
             from_email="Sam Smith <sam.smith@example.com>",
             to=["John Doe <john.doe@example.com>"],
+        )
+        msg_with_settings = EmailMessage(
+            subject="Hello, World!",
+            body="Hello, World!",
+            from_email="Sam Smith <sam.smith@example.com>",
+            to=["John Doe <john.doe@example.com>"],
+        )
+        # additional setting to test existing settings preserved then sandbox_mode populated
+        msg_with_settings.mail_settings = MailSettings(
+            bypass_list_management=BypassListManagement(enable=True)
         )
 
         # Sandbox mode should be False
@@ -25,6 +36,7 @@ class TestSandboxMode(SimpleTestCase):
             result = backend._build_sg_mail(msg)
             self.assertIn("mail_settings", result)
             self.assertIn("sandbox_mode", result["mail_settings"])
+            self.assertNotIn("bypass_list_management", result["mail_settings"])
             self.assertFalse(result["mail_settings"]["sandbox_mode"]["enable"])
 
         # Sandbox mode should be True
@@ -34,6 +46,7 @@ class TestSandboxMode(SimpleTestCase):
             result = backend._build_sg_mail(msg)
             self.assertIn("mail_settings", result)
             self.assertIn("sandbox_mode", result["mail_settings"])
+            self.assertNotIn("bypass_list_management", result["mail_settings"])
             self.assertTrue(result["mail_settings"]["sandbox_mode"]["enable"])
 
         # Sandbox mode should be True (by default when DEBUG==True)
@@ -43,6 +56,7 @@ class TestSandboxMode(SimpleTestCase):
             result = backend._build_sg_mail(msg)
             self.assertIn("mail_settings", result)
             self.assertIn("sandbox_mode", result["mail_settings"])
+            self.assertNotIn("bypass_list_management", result["mail_settings"])
             self.assertTrue(result["mail_settings"]["sandbox_mode"]["enable"])
 
         # Sandbox mode should be False
@@ -52,4 +66,49 @@ class TestSandboxMode(SimpleTestCase):
             result = backend._build_sg_mail(msg)
             self.assertIn("mail_settings", result)
             self.assertIn("sandbox_mode", result["mail_settings"])
+            self.assertNotIn("bypass_list_management", result["mail_settings"])
             self.assertFalse(result["mail_settings"]["sandbox_mode"]["enable"])
+
+        # Sandbox mode should be False with existing settings preserved
+        with override_settings(DEBUG=False, SENDGRID_SANDBOX_MODE_IN_DEBUG=True):
+            backend = SendgridBackend(api_key="stub")
+
+            result = backend._build_sg_mail(msg_with_settings)
+            self.assertIn("mail_settings", result)
+            self.assertIn("sandbox_mode", result["mail_settings"])
+            self.assertIn("bypass_list_management", result["mail_settings"])
+            self.assertFalse(result["mail_settings"]["sandbox_mode"]["enable"])
+            self.assertTrue(result["mail_settings"]["bypass_list_management"]["enable"])
+
+        # Sandbox mode should be True with existing settings preserved
+        with override_settings(DEBUG=True, SENDGRID_SANDBOX_MODE_IN_DEBUG=True):
+            backend = SendgridBackend(api_key="stub")
+
+            result = backend._build_sg_mail(msg_with_settings)
+            self.assertIn("mail_settings", result)
+            self.assertIn("sandbox_mode", result["mail_settings"])
+            self.assertIn("bypass_list_management", result["mail_settings"])
+            self.assertTrue(result["mail_settings"]["sandbox_mode"]["enable"])
+            self.assertTrue(result["mail_settings"]["bypass_list_management"]["enable"])
+
+        # Sandbox mode should be True (by default when DEBUG==True) with existing settings preserved
+        with override_settings(DEBUG=True):
+            backend = SendgridBackend(api_key="stub")
+
+            result = backend._build_sg_mail(msg_with_settings)
+            self.assertIn("mail_settings", result)
+            self.assertIn("sandbox_mode", result["mail_settings"])
+            self.assertIn("bypass_list_management", result["mail_settings"])
+            self.assertTrue(result["mail_settings"]["sandbox_mode"]["enable"])
+            self.assertTrue(result["mail_settings"]["bypass_list_management"]["enable"])
+
+        # Sandbox mode should be False with existing settings preserved
+        with override_settings(DEBUG=True, SENDGRID_SANDBOX_MODE_IN_DEBUG=False):
+            backend = SendgridBackend(api_key="stub")
+
+            result = backend._build_sg_mail(msg_with_settings)
+            self.assertIn("mail_settings", result)
+            self.assertIn("sandbox_mode", result["mail_settings"])
+            self.assertIn("bypass_list_management", result["mail_settings"])
+            self.assertFalse(result["mail_settings"]["sandbox_mode"]["enable"])
+            self.assertTrue(result["mail_settings"]["bypass_list_management"]["enable"])


### PR DESCRIPTION
Handles the mail_settings attribute in SendgridBackend._build_sg_mail.

Note: if sandbox_mode is set in the supplied settings, its value is
overwritten with the default defined in this library's documentation to
preserve as much existing behavior as possible. But this can be changed if
desired to allow the user to provide a per-message sandbox_mode value in the
supplied MailSettings.