### PR TITLE
Fix for issue#113:  Missed personalization dicts

### DIFF
--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -441,10 +441,10 @@ class SendgridBackend(BaseEmailBackend):
 
         if hasattr(msg, "personalizations"):
             for personalization in msg.personalizations:
-                if type(personalization) == Dict:
+                if isinstance(personalization, Dict):
                     personalization = dict_to_personalization(personalization)
 
-                assert type(personalization) == Personalization
+                assert isinstance(personalization, Personalization)
 
                 mail.add_personalization(
                     self._build_sg_personalization(


### PR DESCRIPTION
Fix missed personalization dicts caused by `type(personalization) == Dict`
Issue #113 