### PR TITLE
Drop unsupported versions of python and Django

### DIFF
--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,17 +27,16 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
+
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python
+    - name: Set up Python ${{ matrix.python-version }}
       uses: actions/setup-python@v5
       with:
-        python-version: |
-          3.9
-          3.10
-          3.11
-          3.12
-          3.13
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -27,16 +27,17 @@ jobs:
 
   test:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
-
     steps:
     - uses: actions/checkout@v4
-    - name: Set up Python ${{ matrix.python-version }}
+    - name: Set up Python
       uses: actions/setup-python@v5
       with:
-        python-version: ${{ matrix.python-version }}
+        python-version: |
+          3.9
+          3.10
+          3.11
+          3.12
+          3.13
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/pipeline.yml
+++ b/.github/workflows/pipeline.yml
@@ -29,7 +29,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: ['3.7', '3.8', '3.9', '3.10', '3.11', '3.12', '3.13']
+        python-version: ['3.9', '3.10', '3.11', '3.12', '3.13']
 
     steps:
     - uses: actions/checkout@v4

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,8 +18,6 @@ classifiers = [
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
     "Programming Language :: Python :: 3.11",
@@ -27,7 +25,7 @@ classifiers = [
     "Programming Language :: Python :: 3.13",
 ]
 dependencies = [
-    "django >=1.8",
+    "django >=4.2",
     "python-http-client >=3.0.0",
     "sendgrid >=5.0.0",
 ]
@@ -60,16 +58,12 @@ legacy_tox_ini = """
     [tox]
     # https://docs.djangoproject.com/en/5.1/faq/install/#what-python-version-can-i-use-with-django
     env_list =
-        django{18,110,111,21,22,3,31}-py{37,38,39}-sendgrid{5,6}
-        django{32}-py{37,38,39,310,311,312}-sendgrid{5,6}
-        django{4,41,42}-py{38,39,310,311,312}-sendgrid{5,6}
+        django{42}-py{39,310,311,312}-sendgrid{5,6}
         django{5}-py{310,311,312}-sendgrid{5,6}
         django{51}-py{310,311,312,313}-sendgrid{5,6}
 
     [gh]
     python =
-        3.7: py37
-        3.8: py38
         3.9: py39
         3.10: py310
         3.11: py311
@@ -78,16 +72,7 @@ legacy_tox_ini = """
 
     [testenv]
     deps =
-        django18: Django>=1.8,<1.9
-        django110: Django>=1.10,<1.11
-        django111: Django>=1.11,<2
-        django21: Django>=2.1,<2.2
-        django22: Django>=2.2,<2.3
-        django3: Django>=3.0,<3.1
-        django31: Django>=3.1,<3.2
-        django32: Django>=3.2,<4
-        django4: Django>=4.0,<4.1
-        django41: Django>=4.1,<4.2
+        django42: Django>=4.2,<4.3
         django5: Django>=5.0,<5.1
         django51: Django>=5.1,<5.2
         sendgrid5: sendgrid>=5,<6

--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -7,8 +7,9 @@ import sys
 import threading
 import uuid
 import warnings
+from collections.abc import Iterable
 from email.mime.base import MIMEBase
-from typing import TYPE_CHECKING, Dict, Iterable, List, Optional, Tuple, Union
+from typing import TYPE_CHECKING, Optional, Union
 
 from django.conf import settings
 from django.core.exceptions import ImproperlyConfigured
@@ -41,7 +42,7 @@ from sendgrid_backend.util import (
     get_django_setting,
 )
 
-DjangoAttachment = Union[Tuple[str, Union[bytes, str], str], MIMEBase]
+DjangoAttachment = Union[tuple[str, Union[bytes, str], str], MIMEBase]
 
 # Need to change imports because of breaking changes in sendgrid's v6 api
 # https://github.com/sendgrid/sendgrid-python/releases/tag/v6.0.0
@@ -258,7 +259,7 @@ class SendgridBackend(BaseEmailBackend):
 
         return sg_attch
 
-    def _parse_email_address(self, address: str) -> Tuple[str, Optional[str]]:
+    def _parse_email_address(self, address: str) -> tuple[str, Optional[str]]:
         """
         Returns a tuple of (addr, name) from an address string
         """
@@ -271,7 +272,7 @@ class SendgridBackend(BaseEmailBackend):
         self,
         msg: EmailMessage,
         extra_headers: Iterable[Header],
-        to: Optional[List[str]] = None,
+        to: Optional[list[str]] = None,
         existing_personalizations: Optional[Personalization] = None,
     ) -> Personalization:
         """
@@ -362,7 +363,7 @@ class SendgridBackend(BaseEmailBackend):
 
         return personalization
 
-    def _build_sg_mail(self, msg: EmailMessage) -> Dict:
+    def _build_sg_mail(self, msg: EmailMessage) -> dict:
         """
         Serializes a Django EmailMessage into its JSON representation.
 
@@ -454,7 +455,7 @@ class SendgridBackend(BaseEmailBackend):
 
         if hasattr(msg, "personalizations"):
             for personalization in msg.personalizations:
-                if isinstance(personalization, Dict):
+                if isinstance(personalization, dict):
                     personalization = dict_to_personalization(personalization)
 
                 assert isinstance(personalization, Personalization)

--- a/sendgrid_backend/util.py
+++ b/sendgrid_backend/util.py
@@ -1,4 +1,4 @@
-from typing import Any, Dict
+from typing import Any
 
 import sendgrid
 from django.conf import settings
@@ -19,10 +19,10 @@ def get_django_setting(setting_str, default=None):
     return default
 
 
-def dict_to_personalization(data: Dict[Any, Any]) -> Personalization:
+def dict_to_personalization(data: dict[Any, Any]) -> Personalization:
     """
     Reverses Sendgrid's Personalization.get() method to create a Personalization
-    object from its emitted data structure (in the form of a Dict)
+    object from its emitted data structure (in the form of a dict)
     """
     personalization = Personalization()
 


### PR DESCRIPTION
Probably doesn't warrant a new release but I think it makes sense to drop support for unsupported versions of Django from the test matrix.

- Test against Django 4.2 - 5.1 (4.2 was missing before)
- Drop support for EOL Python 3.8
- Use Python 3.9 generic types