### PR TITLE
Handle blank addresses in CC and BCC lists, as these cause a Sendgrid error

### DIFF
--- a/sendgrid_backend/mail.py
+++ b/sendgrid_backend/mail.py
@@ -301,7 +301,8 @@ class SendgridBackend(BaseEmailBackend):
 
             personalization = Personalization()
             for addr in to:
-                personalization.add_to(Email(*self._parse_email_address(addr)))
+                if addr:
+                    personalization.add_to(Email(*self._parse_email_address(addr)))
 
         elif existing_personalizations.tos:
             personalization = existing_personalizations
@@ -310,11 +311,13 @@ class SendgridBackend(BaseEmailBackend):
 
         if not personalization.ccs:
             for addr in msg.cc:
-                personalization.add_cc(Email(*self._parse_email_address(addr)))
+                if addr:
+                    personalization.add_cc(Email(*self._parse_email_address(addr)))
 
         if not personalization.bccs:
             for addr in msg.bcc:
-                personalization.add_bcc(Email(*self._parse_email_address(addr)))
+                if addr:
+                    personalization.add_bcc(Email(*self._parse_email_address(addr)))
 
         if not personalization.custom_args:
             for k, v in getattr(msg, "custom_args", {}).items():

--- a/test/test_mail.py
+++ b/test/test_mail.py
@@ -48,8 +48,8 @@ class TestMailGeneration(SimpleTestCase):
             body="Hello, World!",
             from_email="Sam Smith <sam.smith@example.com>",
             to=["John Doe <john.doe@example.com>", "jane.doe@example.com"],
-            cc=["Stephanie Smith <stephanie.smith@example.com>"],
-            bcc=["Sarah Smith <sarah.smith@example.com>"],
+            cc=["Stephanie Smith <stephanie.smith@example.com>", ""],  # Include blank address to confirm that it's ignored
+            bcc=["Sarah Smith <sarah.smith@example.com>", ""],  # Include blank address to confirm that it's ignored
             reply_to=["Sam Smith <sam.smith@example.com>"],
         )
 


### PR DESCRIPTION
When accidentally sending blank addresses in the lists for CC or BCC, Sendgrid's API will raise an exception. Therefore, we can ignore them when constructing the email object.

I've omitted the same check from the TO list, as we probably want an exception raised here since something more serious is wrong.