### PR TITLE
Upgrade support django5.2 and drop django5.0

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -59,7 +59,6 @@ legacy_tox_ini = """
     # https://docs.djangoproject.com/en/5.1/faq/install/#what-python-version-can-i-use-with-django
     env_list =
         django{42}-py{39,310,311,312}-sendgrid{5,6}
-        django{5}-py{310,311,312}-sendgrid{5,6}
         django{51}-py{310,311,312,313}-sendgrid{5,6}
         django{52}-py{310,311,312,313}-sendgrid{5,6}
 
@@ -74,7 +73,6 @@ legacy_tox_ini = """
     [testenv]
     deps =
         django42: Django>=4.2,<4.3
-        django5: Django>=5.0,<5.1
         django51: Django>=5.1,<5.2
         django52: Django>=5.2,<5.3
         sendgrid5: sendgrid>=5,<6


### PR DESCRIPTION
This PR adds support for Django 5.2 LTS.

## Summary

* Added support for Django 5.2 (EOL Version)
* Dropped EOL Django 5.0