### PR TITLE
Add Django 4.1/5.1/5.2 to classifiers

### DIFF
--- a/pyproject.toml
+++ b/pyproject.toml
@@ -15,6 +15,9 @@ keywords = [
 ]
 classifiers = [
     "Framework :: Django",
+    "Framework :: Django :: 4.2",
+    "Framework :: Django :: 5.1",
+    "Framework :: Django :: 5.2",
     "Intended Audience :: Developers",
     "License :: OSI Approved :: MIT License",
     "Programming Language :: Python :: 3",


### PR DESCRIPTION
Extremely minor change, but this would be useful to get the PyPI page to pick up which Django versions are supported, similarly to how it does with the Python versions, which are already in the classifiers. 
Explicit support in the classifiers would allow downstream usages to be informed about any Django version support changes as part of their CIs/automated processes, rather than having to parse the changelogs, etc. manually for that information. (And might prevent low-hanging questions about what the supported versions are.)

Django 4.2, 5.1, and 5.2 are the ones tested for in the pyproject+tox matrix, so no actual changes are needed to commit to these as the supported versions, other than adding them to the classifiers.
